### PR TITLE
2018_04_01

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gpslogger/build.gradle
+++ b/gpslogger/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath 'com.canelmas.let:let-plugin:0.1.10'
         classpath "com.mendhak.gradlecrowdin:crowdin-plugin:0.1.0"
         classpath 'org.jacoco:org.jacoco.core:0.7.4.201502262128'

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/csv/CSVFileLoggerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/csv/CSVFileLoggerTest.java
@@ -4,12 +4,22 @@ import android.location.Location;
 import android.test.suitebuilder.annotation.SmallTest;
 
 import com.mendhak.gpslogger.common.BundleConstants;
+import com.mendhak.gpslogger.common.Session;
+import com.mendhak.gpslogger.common.Strings;
+import com.mendhak.gpslogger.loggers.Files;
 import com.mendhak.gpslogger.loggers.MockLocations;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Date;
 
 @SmallTest
 @RunWith(MockitoJUnitRunner.class)
@@ -180,7 +190,64 @@ public class CSVFileLoggerTest {
     }
 
 
+    @Test
+    /**
+     * Purpose : check getName() function
+     * Input : Null
+     * Expected : return "TXT"
+     */
+    public void getName_ReturnName(){
+        CSVFileLogger plain = new CSVFileLogger(null,null);
 
+        String name = plain.getName();
+        assertEquals("TXT", name);
+    }
 
+    @Test
+        /**
+         * Purpose : check annotate(String description, Location loc) function
+         * Input : put  CSVFileLogger(fileAnnotate,47),   MockLocations.builder("MOCK", 12.222,14.151) -> print to fileAnnotate
+         * Expected : "time,lat,lon,elevation,accuracy,bearing,speed,satellites,provider,hdop,vdop,pdop,geoidheight,ageofdgpsdata,dgpsid,activity,battery,annotation1970-01-01T00:00:00.000Z,12.222000,14.151000,,,,,0,MOCK,,,,,,,,47,"testAnnotate"
+         */
+    public void annotate_CreateFile() throws IOException {
+        File fileAnnotate = new File("textAnnotate.csv");
+        fileAnnotate.delete();
+        CSVFileLogger plain = new CSVFileLogger(fileAnnotate,47);
+        Location loc = MockLocations.builder("MOCK", 12.222,14.151).build();
+        String description = "testAnnotate";
+
+        try {
+            plain.annotate(description, loc);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        if(Files.reallyExists(fileAnnotate)) {
+            FileInputStream reader = new FileInputStream(fileAnnotate);
+            BufferedInputStream input = new BufferedInputStream(reader);
+            String header =  "time,lat,lon,elevation,accuracy,bearing,speed,satellites,provider,hdop,vdop,pdop,geoidheight,ageofdgpsdata,dgpsid,activity,battery,annotation\n";
+
+            String content = "1970-01-01T00:00:00.000Z,12.222000,14.151000,,,,,0,MOCK,,,,,,,,47,\"testAnnotate\"";
+            byte [] tempHeader = new byte[header.getBytes().length];
+            byte [] tempContent = new byte[content.getBytes().length];
+
+            input.read(tempHeader);
+            input.read(tempContent);
+            input.close();
+
+            String compareHeader = new String(tempHeader);
+            String compareContent = new String(tempContent);
+
+            String expected = header + content;
+            String actual = compareHeader + compareContent;
+
+            assertEquals(expected,actual);
+
+        }
+        else {
+            // return failure;
+            assertEquals(0,1);
+        }
+    }
 
 }

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/geojson/GeoJSONLoggerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/geojson/GeoJSONLoggerTest.java
@@ -100,4 +100,17 @@ public class GeoJSONLoggerTest {
 
 
     }
+
+    @Test
+    /**
+     * Purpose : check getName() function
+     * Input : Null
+     * Expected : return "GeoJSON"
+     */
+    public void getName_ReturnName(){
+        GeoJSONLogger geoJSONLogger = new GeoJSONLogger(null, false);
+        String name = geoJSONLogger.getName();
+        assertEquals("GeoJSON", name);
+    }
+
 }

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx10FileLoggerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx10FileLoggerTest.java
@@ -1,0 +1,62 @@
+package com.mendhak.gpslogger.loggers.gpx;
+
+import android.location.Location;
+import android.test.suitebuilder.annotation.SmallTest;
+
+import com.mendhak.gpslogger.BuildConfig;
+import com.mendhak.gpslogger.common.Strings;
+import com.mendhak.gpslogger.loggers.MockLocations;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@SmallTest
+@RunWith(MockitoJUnitRunner.class)
+public class Gpx10FileLoggerTest {
+    @Test
+    /**
+     * Purpose : check getWriteHandler() function
+     * Input : getWriteHandler()
+     * Expected : Gpx10WriteHandler(null, null, null, true);
+     * */
+    public void getWriteHandler(){
+        Gpx10FileLogger gpx10FileLogger = new Gpx10FileLogger(null, true);
+        Runnable  gpx10WriteHandler = gpx10FileLogger.getWriteHandler(null, null, null, true);
+        assertNotNull(gpx10WriteHandler);
+    }
+
+    @Test
+    /**
+     * 진행중.
+     * Purpose : check write(Location loc) function
+     * Input : write(Location loc)
+     * Expected :
+     * */
+    public void write() throws Exception {
+        File fileGPX10Write = new File("GPX10Write.csv");
+        Gpx10FileLogger gpx10FileLogger = new Gpx10FileLogger(fileGPX10Write, true);
+        Location loc = MockLocations.builder("MOCK", 12.193, 19.111).build();
+        gpx10FileLogger.write(loc);
+
+//        String expected = "<trkpt lat=\"12.193\" lon=\"19.111\"><ele>9001.0</ele><time>2011-09-17T18:45:33Z</time>" +
+//                "<course>91.88</course><speed>188.44</speed><src>MOCK</src></trkpt>\n</trkseg></trk></gpx>";
+//        byte [] bytes = new byte[expected.getBytes().length];
+//        RandomAccessFile raf = new RandomAccessFile(fileGPX10Write, "rw");
+//        raf.seek((fileGPX10Write.length() -  "</trk></gpx>".length()));
+//        raf.read(bytes);
+//        raf.close();
+//        String result = new String(bytes);
+//        assertEquals(expected, result);
+    }
+}

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx11FileLoggerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx11FileLoggerTest.java
@@ -1,0 +1,33 @@
+package com.mendhak.gpslogger.loggers.gpx;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+import com.mendhak.gpslogger.BuildConfig;
+import com.mendhak.gpslogger.common.Strings;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+@SmallTest
+@RunWith(MockitoJUnitRunner.class)
+public class Gpx11FileLoggerTest {
+    @Test
+    /**
+     * Purpose : check getWriteHandler() function
+     * Input : getWriteHandler()
+     * Expected : Gpx10WriteHandler(null, null, null, true);
+     * */
+    public void getWriteHandler(){
+        Gpx10FileLogger gpx11FileLogger = new Gpx11FileLogger(null, true);
+        Runnable  gpx11WriteHandler = gpx11FileLogger.getWriteHandler(null, null, null, true);
+        assertNotNull(gpx11WriteHandler);
+    }
+
+}

--- a/gpslogger/test.geojson
+++ b/gpslogger/test.geojson
@@ -1,0 +1,11 @@
+{"type": "FeatureCollection","features": [
+{"type": "Feature","properties":{"time":"1970-01-01T00:00:00.000Z","provider":"MOCK","time_long":"0","altitude":"9001.0","bearing":"91.88","speed":"188.44"},"geometry":{"type":"Point","coordinates":[19.111,12.193]}}
+,{"type": "Feature","properties":{"time":"1970-01-01T00:00:00.000Z","provider":"MOCK","time_long":"0","altitude":"9001.0","bearing":"91.88","speed":"188.44"},"geometry":{"type":"Point","coordinates":[19.111,12.193]}}
+,{"type": "Feature","properties":{"time":"1970-01-01T00:00:00.000Z","provider":"MOCK","time_long":"0","altitude":"9001.0","bearing":"91.88","speed":"188.44"},"geometry":{"type":"Point","coordinates":[19.111,12.193]}}
+,{"type": "Feature","properties":{"time":"1970-01-01T00:00:00.000Z","provider":"MOCK","time_long":"0","altitude":"9001.0","bearing":"91.88","speed":"188.44"},"geometry":{"type":"Point","coordinates":[19.111,12.193]}}
+,{"type": "Feature","properties":{"time":"1970-01-01T00:00:00.000Z","provider":"MOCK","time_long":"0","altitude":"9001.0","bearing":"91.88","speed":"188.44"},"geometry":{"type":"Point","coordinates":[19.111,12.193]}}
+,{"type": "Feature","properties":{"time":"1970-01-01T00:00:00.000Z","provider":"MOCK","time_long":"0","altitude":"9001.0","bearing":"91.88","speed":"188.44"},"geometry":{"type":"Point","coordinates":[19.111,12.193]}}
+,{"type": "Feature","properties":{"time":"1970-01-01T00:00:00.000Z","provider":"MOCK","time_long":"0","altitude":"9001.0","bearing":"91.88","speed":"188.44"},"geometry":{"type":"Point","coordinates":[19.111,12.193]}}
+,{"type": "Feature","properties":{"time":"1970-01-01T00:00:00.000Z","provider":"MOCK","time_long":"0","altitude":"9001.0","bearing":"91.88","speed":"188.44"},"geometry":{"type":"Point","coordinates":[19.111,12.193]}}
+,{"type": "Feature","properties":{"time":"1970-01-01T00:00:00.000Z","provider":"MOCK","time_long":"0","altitude":"9001.0","bearing":"91.88","speed":"188.44"},"geometry":{"type":"Point","coordinates":[19.111,12.193]}}
+]}

--- a/gpslogger/textAnnotate.csv
+++ b/gpslogger/textAnnotate.csv
@@ -1,0 +1,2 @@
+time,lat,lon,elevation,accuracy,bearing,speed,satellites,provider,hdop,vdop,pdop,geoidheight,ageofdgpsdata,dgpsid,activity,battery,annotation
+1970-01-01T00:00:00.000Z,12.222000,14.151000,,,,,0,MOCK,,,,,,,,47,"testAnnotate"

--- a/gpsloggerwear/build.gradle
+++ b/gpsloggerwear/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 10 13:55:02 CEST 2017
+#Sun Apr 01 17:46:49 KST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -6,7 +6,7 @@
 @rem ##########################################################################
 
 @rem Set local scope for the variables with windows NT shell
-if "%OS%"=="Windows_NT" setlocal
+if "%OS%"=="Windows_NT" setlocalㅓ
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 set DEFAULT_JVM_OPTS=


### PR DESCRIPTION
loggers/csv
    CSVFileLogger class에 대한 test case 추가
CSVFileLoggerTest.java에 testcase 추가함
1. getName_ReturnName()
    CSVFileLogger 커버리지 100% 만들기.
2. annotate_CreateFile()
    /**
     * Purpose : check annotate(String description, Location loc) function
     * Input : put  CSVFileLogger(fileAnnotate,47),   MockLocations.builder("MOCK", 12.222,14.151) -> print to fileAnnotate
     * Expected : "time,lat,lon,elevation,accuracy,bearing,speed,satellites,provider,hdop,vdop,pdop,geoidheight,ageofdgpsdata,dgpsid,activity,battery,annotation1970-01-01T00:00:00.000Z,12.222000,14.151000,,,,,0,MOCK,,,,,,,,47,"testAnnotate"
     */
     파일을 생성하는 함수라서 임시로 파일 생성 후 그 파일의 값을 확인하는 방식으로 테스트 진행함.
    // write 메소드는 Session을 써야해서 못함.

loggers/customurl
    CustomUrlLogger에서 write와 annotate 함수가 테스트되지 않음을 확인
        그러나 write는 Seesion을 써야함.
        annotate는 jobManager.java를 통해 ScheduledExecutorService까지 포함되어 있어 내용이 복잡함으로 시간이 좀더 필요함.
    CustomUrlJob의 경우 0%의 테스트 커버리지로 얽혀있는 부분이 많아 손대기가 힘들듯...
loggers/geojson
    GeoJSONLogger class에 대한 test case 추가
    GeoJSONLoggerTest.java에 testcase 추가함
    1. getName_ReturnName()
        GeoJSONLogger 커버리지 100% 만들기.
    // write 부분 failure 확인.
    GeoJSONWriterPoints.java 66~68 line.
        테스트되지 않는 라인 발견. IOExceoption try-catch 구문이라 조치에 어려움 발생.
    GeoJSONWriterPoints.java 97~99 line.
        getString(boolean append)함수 부분에서 테스트 되지 않은 부분을 발견.
        Location.java에 private로 선언시 초기화되는 값에 의해 동작하는 부분이라 조치 불가능 확인.
loggers/gpx
    Gpx10FileLoggerTest.java 파일 생성
    1. getWriteHandler test case 추가
    2. write() test case 작성중. 동작은 확인. 결과 값이 올바른지 확인중
    Gpx11FileLoggerTest.java 파일 생성
    1. getWriteHandler test case 추가